### PR TITLE
Tidy up search card

### DIFF
--- a/src/app/card-display/card-display.component.html
+++ b/src/app/card-display/card-display.component.html
@@ -4,6 +4,7 @@
         <span class="ml-4 badge badge-pill badge-info">{{item.domainType}}</span>
     </div>
     <div class="card-body">
+        <!-- breadcrumb link does not work for DataElement
         <nav *ngIf="item.breadcrumbs !== undefined" aria-label="breadcrumb">
             <ol class="breadcrumb">
                 <li *ngFor="let breadcrumb of item.breadcrumbs" class="breadcrumb-item">
@@ -11,6 +12,7 @@
                 </li>
             </ol>
         </nav>
+        -->
         <p class="card-text">{{item.description}}</p>
     </div>
 </div>


### PR DESCRIPTION
- Put the model title into a card header
- Put the domain type into a pill
- Display the breadcrumbs (note: link to DataClass does not work - to be covered separately)

The card displays all the information that is returned by the search endpoint.

Closes #19 