### PR TITLE
Add search result pagination

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { AppContainerComponent } from './app-container/app-container.component';
 import { UiViewComponent } from './shared/ui-view/ui-view.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { MaterialModule } from './modules/material/material.module';
 import { ModalModule } from './modules/modal/modal.module';
 import { MdmResourcesModule } from './modules/mdm-resources/mdm-resources.module';
 import { environment } from '@env/environment';
@@ -33,9 +34,11 @@ import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
 import { SearchComponent } from './search/search.component';
 import { FormsModule } from '@angular/forms';
 import { CardDisplayComponent } from './card-display/card-display.component';
+import { SearchPaginatorComponent } from './shared/search-paginator/search-paginator';
 import { LinkElementComponent } from './shared/utility/link-element/link-element.component';
 import { DataModelComponent } from './data-model/data-model.component';
 import { DataElementComponent } from './data-element/data-element.component'; 
+
 
 @NgModule({
   declarations: [
@@ -44,6 +47,7 @@ import { DataElementComponent } from './data-element/data-element.component';
     UiViewComponent,
     SearchComponent,
     CardDisplayComponent,
+    SearchPaginatorComponent,
     LinkElementComponent,
     DataModelComponent,
     DataElementComponent
@@ -51,6 +55,7 @@ import { DataElementComponent } from './data-element/data-element.component';
   imports: [
     BrowserModule,
     DashboardModule,
+    MaterialModule,
     ModalModule,
     HttpClientModule,
     MdmResourcesModule.forRoot({

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -3,8 +3,7 @@
         <h1>Search Page</h1>
 
         <div class="d-flex justify-content-center">
-            <input type="text"  id="searchBarInput" [(ngModel)]="searchTerm" class="form-control" placeholder="I'm looking for..."> 
-            <button (click)="onSearchClick()" class="ml-1">Search!</button>
+            <input #searchInputControl type="text"  id="searchBarInput" [(ngModel)]="searchTerm" class="form-control" placeholder="I'm looking for..."> 
         </div>
     </div>
 </div>
@@ -12,10 +11,23 @@
     <div class="col-12">
         <div *ngIf="!neverSearched">
             <div *ngIf="searchResults.length > 0; else elseBlock" >
+                <div class="heading-container">
+                    <h4 class="mt-4">Search result(s) <span class="badge badge-element-count">{{searchCount}}</span> </h4>
+                  </div>                
                 <div *ngFor="let result of searchResults">
                     <mdm-card-display [item]="result"></mdm-card-display>
                 </div>
             </div>
+
+            <div class="mdm--mat-pagination">
+                <search-paginator #searchPaginator *ngIf="formData.showSearchResult"
+                                [pageSizeOptions]="[5, 10, 20, 50]"
+                                [length]="searchCount"
+                                [pageSize]="10"
+                                (page)="getServerData($event)"
+                                showFirstLastButtons>
+                </search-paginator>
+            </div>       
         
             <ng-template #elseBlock>There are no results for term {{searchTerm}}.</ng-template>
         </div>

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -1,5 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef} from '@angular/core';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MdmResourcesService } from "@mdm/services/mdm-resources/mdm-resources.service";
+import { Observable, Subject, fromEvent } from 'rxjs';
+import { debounceTime, map, filter, distinctUntilChanged } from 'rxjs/operators';
 
 @Component({
   selector: 'mdm-search',
@@ -8,41 +11,135 @@ import { MdmResourcesService } from "@mdm/services/mdm-resources/mdm-resources.s
 })
 export class SearchComponent implements OnInit {
   searchTerm: string = "";
+  searchCount: number;
   searchResults: any[];
   neverSearched: boolean;
 
-    constructor(public resources: MdmResourcesService) { }
+  @ViewChild('searchInputControl', { static: true })
+  searchInputControl: ElementRef;
+  
+  pageIndex: any;
+  isLoading: boolean;
+
+  pageEvent: PageEvent;
+
+  //TODO use when adding filtering
+  formData: any = {
+    showSearchResult: false
+    //labelOnly: false,
+    //exactMatch: false,
+    //selectedDomainTypes: {
+    //  DataModel: false,
+    //  DataClass: false,
+    //  DataElement: false,
+    //  DataType: false,
+    //  EnumerationValue: false
+    //},
+    //classifiers: [],
+
+    //lastDateUpdatedFrom: null,
+    //lastDateUpdatedTo: null,
+
+    //createdFrom: null,
+    //createdTo: null
+  };
+
+  constructor(public resources: MdmResourcesService) { }
 
   ngOnInit(): void {
     this.neverSearched = true;
+
+    fromEvent(this.searchInputControl.nativeElement, 'keyup').pipe(map((event: any) => {
+      return event.target.value;
+    }),
+      filter((res: any) => res.length >= 0),
+      debounceTime(500),
+      distinctUntilChanged()
+    ).subscribe((text: string) => {
+      if (text.length === 0) {
+        this.formData.showSearchResult = false;
+        this.searchResults = [];
+        this.isLoading = false;
+      } else {
+        this.formData.showSearchResult = true;
+        this.fetch(10, 0).subscribe(res => {
+          this.searchResults = res.body.items;
+          this.isLoading = false;
+          this.neverSearched = false;
+  
+          this.searchCount = res.body.count > 0 ? res.body.count : -1;
+        }, () => {
+          this.isLoading = false;
+        }
+        );
+      }
+    });
+  }    
+
+  getServerData($event) {
+    this.fetch($event.pageSize, $event.pageIndex).subscribe(res => {
+      this.searchResults = res.body.items;
+      this.searchCount = res.body.count;
+      this.isLoading = false;
+    }, () => {
+      this.isLoading = false;
+    });
   }
 
-  onSearchClick(): void {
-    if (this.searchTerm !== "") {
-      this.doSearch().subscribe(res => {
-        this.neverSearched = false;
-        this.searchResults = res.body.items;
-      });
+  fetch(pageSize: number, offset: number): Observable<any> {
+    this.isLoading = true;
+
+    if (!this.formData.showSearchResult) {
+      return new Observable();
     }
-  }
 
-  doSearch(): any {
+    //TODO use these when adding filtering
+    /*const filterDataTypes = [];
+    if (this.formData.selectedDomainTypes.DataModel) {
+      filterDataTypes.push('DataModel');
+    }
+    if (this.formData.selectedDomainTypes.DataClass) {
+      filterDataTypes.push('DataClass');
+    }
+    if (this.formData.selectedDomainTypes.DataElement) {
+      filterDataTypes.push('DataElement');
+    }
+    if (this.formData.selectedDomainTypes.DataType) {
+      filterDataTypes.push('DataType');
+    }
+    if (this.formData.selectedDomainTypes.EnumerationValue) {
+      filterDataTypes.push('EnumerationValue');
+    }*/
+
+    //let searchText = this.searchInput;
+    /*if (this.formData.exactMatch) {
+      if (searchText[0] !== '"') {
+        searchText = '"' + searchText;
+      }
+      if (searchText[searchText.length - 1] !== '"') {
+        searchText = searchText + '"';
+      }
+    }*/
+
+    /*const classifiersNames = [];
+    this.formData.classifiers.forEach(classifier => {
+      classifiersNames.push(classifier.label);
+    });*/
+
     return this.resources.catalogueItem.search(
-            {
-              classifierFilter: null,
-              classifiers: [],
-              createdAfter: null,
-              createdBefore: null,
-              dataModelTypes: null,
-              domainTypes: [],
-              labelOnly: false,
-              lastUpdatedAfter: null,
-              lastUpdatedBefore: null,
-              limit: 10,
-              offset: 0,
-              pageIndex: 0,
-              pageSize: 10,
-              searchTerm: this.searchTerm
-            });
-  }
+      {
+        classifierFilter: null,
+        classifiers: [],
+        createdAfter: null,
+        createdBefore: null,
+        dataModelTypes: null,
+        domainTypes: [],
+        labelOnly: false,
+        lastUpdatedAfter: null,
+        lastUpdatedBefore: null,
+        limit: pageSize,
+        offset: offset * pageSize,
+        searchTerm: this.searchTerm
+      });
+  }  
 }

--- a/src/app/shared/search-paginator/search-paginator.ts
+++ b/src/app/shared/search-paginator/search-paginator.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { MatPaginator } from '@angular/material/paginator';
+
+@Component({
+  selector: 'search-paginator',
+  template: '<mat-paginator [pageSizeOptions]="pageSizeOptions" [pageSize]="pageSize" [length]="length" showFirstLastButtons (page)="changed($event)"></mat-paginator>'
+})
+export class SearchPaginatorComponent extends MatPaginator implements OnInit {
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    const settings = JSON.parse(localStorage.getItem('userSettings'));
+    if (settings) {
+      this.pageSize = settings.countPerTable;
+      this.pageSizeOptions =  settings.counts;
+    }
+  }
+
+  changed(value) {
+    this.pageSize = value.pageSize;
+    this.pageIndex = value.pageIndex;
+    this.page.emit(value);
+  }
+}

--- a/src/styles/_default.scss
+++ b/src/styles/_default.scss
@@ -175,3 +175,9 @@ a {
     cursor: pointer;
     margin-left: 2px;
 }
+
+.badge-element-count {
+    background-color: #585858;
+    color: #fff;
+    margin: 0px 3px;
+}


### PR DESCRIPTION
- Add a search pagination component based on mat-paginator
- Replace search button with event on keyup (with 500ms bounce time)
- Add pagination component to search results
- Retain some commented code for reference when subsequently implementing filtering

Known defect: when the search term is changed the pagination component does not reset

Closes #13 